### PR TITLE
Use proper logo for IT brands

### DIFF
--- a/custom_components/carbu_com/utils.py
+++ b/custom_components/carbu_com/utils.py
@@ -534,7 +534,7 @@ class ComponentSession(object):
                     'id': block.get('id'),
                     'name': block.get('name'),
                     'url': block.get('url'),
-                    'logo_url': f"https://www.prezzibenzina.it/www2/marker.php?brand={block.get('co')}&status=AP&price={fuel_price}&certified=0&marker_type=1",
+                    'logo_url': f"https://www.prezzibenzina.it/www2/contentImages/brands/logo_{block.get('co')}_small.png",
                     'brand': block.get('co_name'),
                     'address': block.get('address'),
                     'postalcode': block.get('zip'),


### PR DESCRIPTION
Replaces pin-like marker (colored and with price) for IT brands with just the plain 50x50 logo.

The existing behavior is also not consistent with how the application uses colors (green for best price in area, red for worst), so that would require another fix in the remaining places where marker_type=1 is hardcoded in the query string