### PR TITLE
Add Super 98 E10 and E5 sensors for Germany

### DIFF
--- a/custom_components/carbu_com/sensor.py
+++ b/custom_components/carbu_com/sensor.py
@@ -127,7 +127,7 @@ async def dry_setup(hass, config_entry, async_add_devices):
             # await sensorSuper95Neigh.async_update()
             sensors.append(sensorSuper98Neigh)
 
-        if country.lower() in ['be','fr','lu']:
+        if country.lower() in ['be','fr','lu','de']:
             sensorSuper98OfficialE10 = ComponentFuelOfficialSensor(componentData, FuelType.SUPER98_OFFICIAL_E10)
             appendUniqueSensor(sensorSuper98OfficialE10)
             


### PR DESCRIPTION
In Germany we have Super 98 in E10 and E5. Most of the people use the E10 variation as it is much cheaper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Official fuel sensor support for the SUPER98 fuel type has been expanded to include Germany, in addition to Belgium, France, and Luxembourg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->